### PR TITLE
Introduce builder and runner stage in Dockerfile for smaller image size

### DIFF
--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -99,8 +99,6 @@ RUN git clone --depth 1 https://github.com/ejurgensen/forked-daapd.git . \
 
 
 FROM base AS runner
-COPY --from=builder /usr/local/bin/antlr3 /usr/local/bin/antlr3
-RUN chmod 775 /usr/local/bin/antlr3
 COPY --from=builder /tmp/forked-daapd-install /
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ${RUN_DEPS} \

--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM=hassioaddons/debian-base:3.0.0
 # hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+FROM ${BUILD_FROM} as base
 
 ENV BUILD_DEPS \
     autoconf \
@@ -72,6 +72,9 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 RUN curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
     && curl -L https://apt.mopidy.com/mopidy.gpg -o /tmp/mopidy.gpg \
     && apt-key add /tmp/mopidy.gpg
+
+
+FROM base AS builder
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ${BUILD_DEPS} \
@@ -92,8 +95,16 @@ RUN git clone --depth 1 https://github.com/ejurgensen/forked-daapd.git . \
     --enable-spotify \
     --with-libwebsockets \
     && make \
-    && make install
+	&& make install DESTDIR=/tmp/forked-daapd-install
 
+
+FROM base AS runner
+COPY --from=builder /usr/local/bin/antlr3 /usr/local/bin/antlr3
+RUN chmod 775 /usr/local/bin/antlr3
+COPY --from=builder /tmp/forked-daapd-install /
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ${RUN_DEPS} \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/local/etc
 RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
     && sed -i s#"ipv6 = yes"#"ipv6 = no"#g forked-daapd.conf \
@@ -106,11 +117,6 @@ RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
     && sed -i "/pipe_autostart\ =/ s/# *//" forked-daapd.conf \
     && sed -i "/db_path\ =/ s/# *//" forked-daapd.conf \
     && sed -i "/cache_path\ =/ s/# *//" forked-daapd.conf
-
-RUN apt-get remove -y ${BUILD_DEPS} && apt-get autoremove -y
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    ${RUN_DEPS} \
-    && rm -rf /var/lib/apt/lists/*
 
 # Copy root filesystem
 COPY rootfs /

--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -2,110 +2,115 @@ ARG BUILD_FROM=hassioaddons/debian-base:3.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-ENV BUILD_DEPS libcurl4-gnutls-dev \
-               openjdk-11-jre-headless \
-	       build-essential \
-	       libgnutls28-dev \
-	       libprotobuf-c-dev \
-	       libplist-dev \
-	       libsodium-dev \
-	       libpulse-dev \
-	       autotools-dev \
-	       git \
-	       autoconf \
-	       automake \
-	       libtool \
-	       libantlr3c-dev \
-	       libconfuse-dev \
-	       libunistring-dev \
-	       libsqlite3-dev \
-	       libavcodec-dev \
-	       libavformat-dev \
-	       libavfilter-dev \
-	       libswscale-dev \
-	       libavutil-dev \
-	       libasound2-dev \
-	       libmxml-dev \
-	       libgcrypt20-dev \
-	       libavahi-client-dev \
-	       zlib1g-dev \
-	       libevent-dev \
-	       libplist-dev \
-	       libjson-c-dev \
-	       libspotify-dev \
-	       libwebsockets-dev
+ENV BUILD_DEPS \
+    autoconf \
+    automake \
+    autotools-dev \
+    build-essential \
+    git \
+    libantlr3c-dev \
+    libasound2-dev \
+    libavahi-client-dev \
+    libavcodec-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libconfuse-dev \
+    libcurl4-gnutls-dev \
+    libevent-dev \
+    libgcrypt20-dev \
+    libgnutls28-dev \
+    libjson-c-dev \
+    libmxml-dev \
+    libplist-dev \
+    libplist-dev \
+    libprotobuf-c-dev \
+    libpulse-dev \
+    libsodium-dev \
+    libspotify-dev \
+    libsqlite3-dev \
+    libswscale-dev \
+    libtool \
+    libunistring-dev \
+    libwebsockets-dev \
+    openjdk-11-jre-headless \
+    zlib1g-dev
 
-ENV RUN_DEPS   libpulse0 \
-	       libgnutls30 \
-	       libprotobuf-c1 \
-	       libsodium23 \
-	       libantlr3c-3.4-0 \
-	       libconfuse2 \
-	       libunistring2 \
-	       libsqlite3-0 \
-               libavcodec58 \
-	       libavformat58 \
-	       libavfilter7 \
-	       libswscale5 \
-	       libavutil56 \
-	       libasound2 \
-           libasound2-plugins \
-	       libmxml1 \
-	       libgcrypt20 \
-	       libavahi-client3 \
-	       zlib1g \
-	       libevent-2.1-6 \
-	       libplist3 \
-	       libjson-c3 \
-	       libspotify12 \
-	       libspotify-dev \
-	       libwebsockets8 \
-	       libevent-pthreads-2.1-6 \
-	       libcurl3-gnutls
+ENV RUN_DEPS \
+    libantlr3c-3.4-0 \
+    libasound2 \
+    libasound2-plugins \
+    libavahi-client3 \
+    libavcodec58 \
+    libavfilter7 \
+    libavformat58 \
+    libavutil56 \
+    libconfuse2 \
+    libcurl3-gnutls \
+    libevent-2.1-6 \
+    libevent-pthreads-2.1-6 \
+    libgcrypt20 \
+    libgnutls30 \
+    libjson-c3 \
+    libmxml1 \
+    libplist3 \
+    libprotobuf-c1 \
+    libpulse0 \
+    libsodium23 \
+    libspotify-dev \
+    libspotify12 \
+    libsqlite3-0 \
+    libswscale5 \
+    libunistring2 \
+    libwebsockets8 \
+    zlib1g
 
 #RUN sed -i 's/main/main contrib non-free/g' /etc/apt/sources.list
-RUN apt-get update -y
-RUN apt-get install -y --no-install-recommends curl gpg gpg-agent dirmngr apt-transport-https gawk gettext gperf
-RUN curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list
-RUN curl -L https://apt.mopidy.com/mopidy.gpg -o /tmp/mopidy.gpg
-RUN apt-key add /tmp/mopidy.gpg
-RUN apt-get update -y
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    curl gpg gpg-agent dirmngr apt-transport-https gawk gettext gperf \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
+    && curl -L https://apt.mopidy.com/mopidy.gpg -o /tmp/mopidy.gpg \
+    && apt-key add /tmp/mopidy.gpg
 RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y --no-install-recommends ${BUILD_DEPS}
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ${BUILD_DEPS} \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L -o /tmp/antlr-3.4-complete.jar http://www.antlr3.org/download/antlr-3.4-complete.jar && \
-    echo '#!/bin/bash' > /usr/local/bin/antlr3 && \
-    echo 'exec java -cp /tmp/antlr-3.4-complete.jar org.antlr.Tool "$@"' >> /usr/local/bin/antlr3 && \
-    chmod 775 /usr/local/bin/antlr3
+RUN curl -L -o /tmp/antlr-3.4-complete.jar http://www.antlr3.org/download/antlr-3.4-complete.jar \
+    && echo '#!/bin/bash' > /usr/local/bin/antlr3 \
+    && echo 'exec java -cp /tmp/antlr-3.4-complete.jar org.antlr.Tool "$@"' >> /usr/local/bin/antlr3 \
+    && chmod 775 /usr/local/bin/antlr3
 
-RUN cd /tmp && \
-    git clone https://github.com/ejurgensen/forked-daapd.git && \
-    cd /tmp/forked-daapd && \
-    autoreconf -fi && \
-    ./configure \
-      --enable-itunes \
-      --enable-chromecast \
-      --with-pulseaudio \
-      --enable-spotify \
-      --with-libwebsockets && \
-    make && \
-    make install
+WORKDIR /tmp/forked-daapd
+RUN git clone --depth 1 https://github.com/ejurgensen/forked-daapd.git . \
+    && autoreconf -fi \
+    && ./configure \
+    --enable-itunes \
+    --enable-chromecast \
+    --with-pulseaudio \
+    --enable-spotify \
+    --with-libwebsockets \
+    && make \
+    && make install
 
-RUN cd /usr/local/etc \
- && sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
- && sed -i s#"ipv6 = yes"#"ipv6 = no"#g forked-daapd.conf \
- && sed -i s#/srv/music#/share/forked-daapd/music#g forked-daapd.conf \
- && sed -i s#/usr/local/var/cache/forked-daapd/songs3.db#/share/forked-daapd/cache/songs3.db#g forked-daapd.conf \
- && sed -i s#/usr/local/var/cache/forked-daapd/cache.db#/share/forked-daapd/cache/cache.db#g forked-daapd.conf \
- && sed -i s#/usr/local/var/log/forked-daapd.log#/dev/stdout#g forked-daapd.conf \
- && sed -i "/websocket_port\ =/ s/# *//" forked-daapd.conf \
- && sed -i "/trusted_networks\ =/ s/# *//" forked-daapd.conf \
- && sed -i "/pipe_autostart\ =/ s/# *//" forked-daapd.conf \
- && sed -i "/db_path\ =/ s/# *//" forked-daapd.conf \
- && sed -i "/cache_path\ =/ s/# *//" forked-daapd.conf
+WORKDIR /usr/local/etc
+RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
+    && sed -i s#"ipv6 = yes"#"ipv6 = no"#g forked-daapd.conf \
+    && sed -i s#/srv/music#/share/forked-daapd/music#g forked-daapd.conf \
+    && sed -i s#/usr/local/var/cache/forked-daapd/songs3.db#/share/forked-daapd/cache/songs3.db#g forked-daapd.conf \
+    && sed -i s#/usr/local/var/cache/forked-daapd/cache.db#/share/forked-daapd/cache/cache.db#g forked-daapd.conf \
+    && sed -i s#/usr/local/var/log/forked-daapd.log#/dev/stdout#g forked-daapd.conf \
+    && sed -i "/websocket_port\ =/ s/# *//" forked-daapd.conf \
+    && sed -i "/trusted_networks\ =/ s/# *//" forked-daapd.conf \
+    && sed -i "/pipe_autostart\ =/ s/# *//" forked-daapd.conf \
+    && sed -i "/db_path\ =/ s/# *//" forked-daapd.conf \
+    && sed -i "/cache_path\ =/ s/# *//" forked-daapd.conf
 
 RUN apt-get remove -y ${BUILD_DEPS} && apt-get autoremove -y
-RUN apt-get install -y --no-install-recommends ${RUN_DEPS}
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    ${RUN_DEPS} \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy root filesystem
 COPY rootfs /


### PR DESCRIPTION
This change introduces a builder stage and a runner stage in the Dockerfile to bring down the final image size from about 1 GB to 280 MB. 
Thanks for already separating build and run dependencies so well, that made it pretty straightforward.

I tested this Dockerfile on a RPi3B+ 32bit (armv7) and on a RPi4B 64bit (aarch64) (without `libspotify` on the latter).

Please feel free to discuss.