### PR TITLE
Add support for aarch46 (without Spotify)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ audio {
 }
 ```
 
+Note that Spotify support is not available on `aarch64`.
+
 # Raspotify
 
 Spotify connect server, see [the github page](https://github.com/dtcooper/raspotify) for more info.

--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -1,6 +1,7 @@
 ARG BUILD_FROM=hassioaddons/debian-base:3.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM} as base
+ARG BUILD_ARCH
 
 ENV BUILD_DEPS \
     autoconf \
@@ -27,7 +28,6 @@ ENV BUILD_DEPS \
     libprotobuf-c-dev \
     libpulse-dev \
     libsodium-dev \
-    libspotify-dev \
     libsqlite3-dev \
     libswscale-dev \
     libtool \
@@ -35,6 +35,8 @@ ENV BUILD_DEPS \
     libwebsockets-dev \
     openjdk-11-jre-headless \
     zlib1g-dev
+ENV BUILD_DEPS_NO_AARCH64 \
+    libspotify-dev
 
 ENV RUN_DEPS \
     libantlr3c-3.4-0 \
@@ -57,27 +59,35 @@ ENV RUN_DEPS \
     libprotobuf-c1 \
     libpulse0 \
     libsodium23 \
-    libspotify-dev \
-    libspotify12 \
     libsqlite3-0 \
     libswscale5 \
     libunistring2 \
     libwebsockets8 \
     zlib1g
+ENV RUN_DEPS_NO_AARCH64 \
+    libspotify-dev \
+    libspotify12
 
 #RUN sed -i 's/main/main contrib non-free/g' /etc/apt/sources.list
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     curl gpg gpg-agent dirmngr apt-transport-https gawk gettext gperf \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
-    && curl -L https://apt.mopidy.com/mopidy.gpg -o /tmp/mopidy.gpg \
-    && apt-key add /tmp/mopidy.gpg
+RUN if [ ! "$BUILD_ARCH" = "aarch64" ] ; then \
+        curl -L https://apt.mopidy.com/mopidy.list -o /etc/apt/sources.list.d/mopidy.list \
+        && curl -L https://apt.mopidy.com/mopidy.gpg -o /tmp/mopidy.gpg \
+        && apt-key add /tmp/mopidy.gpg; \
+    fi
 
 
 FROM base AS builder
+ARG BUILD_ARCH
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ${BUILD_DEPS} \
+    && if [ ! "$BUILD_ARCH" = "aarch64" ] ; then \
+        apt-get install -y --no-install-recommends \
+        ${BUILD_DEPS_NO_AARCH64}; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L -o /tmp/antlr-3.4-complete.jar http://www.antlr3.org/download/antlr-3.4-complete.jar \
@@ -88,20 +98,33 @@ RUN curl -L -o /tmp/antlr-3.4-complete.jar http://www.antlr3.org/download/antlr-
 WORKDIR /tmp/forked-daapd
 RUN git clone --depth 1 https://github.com/ejurgensen/forked-daapd.git . \
     && autoreconf -fi \
-    && ./configure \
-    --enable-itunes \
-    --enable-chromecast \
-    --with-pulseaudio \
-    --enable-spotify \
-    --with-libwebsockets \
+    && if [ ! "$BUILD_ARCH" = "aarch64" ] ; then \
+        ./configure \
+        --enable-itunes \
+        --enable-chromecast \
+        --with-pulseaudio \
+        --enable-spotify \
+        --with-libwebsockets; \
+    else \
+        ./configure \
+        --enable-itunes \
+        --enable-chromecast \
+        --with-pulseaudio \
+        --with-libwebsockets; \
+    fi \
     && make \
 	&& make install DESTDIR=/tmp/forked-daapd-install
 
 
 FROM base AS runner
+ARG BUILD_ARCH
 COPY --from=builder /tmp/forked-daapd-install /
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     ${RUN_DEPS} \
+    && if [ ! "$BUILD_ARCH" = "aarch64" ] ; then \
+        apt-get install -y --no-install-recommends \
+        ${RUN_DEPS_NO_AARCH64}; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/local/etc
 RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
@@ -120,7 +143,6 @@ RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
 COPY rootfs /
 
 # Build arguments
-ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_REF
 ARG BUILD_VERSION

--- a/forked-daapd/build.json
+++ b/forked-daapd/build.json
@@ -1,5 +1,6 @@
 {
     "build_from": {
+        "aarch64": "hassioaddons/debian-base-aarch64:3.0.0",
         "amd64": "hassioaddons/debian-base-amd64:3.0.0",
         "armv7": "hassioaddons/debian-base-armv7:3.0.0",
         "i386": "hassioaddons/debian-base-i386:3.0.0"

--- a/forked-daapd/config.json
+++ b/forked-daapd/config.json
@@ -12,6 +12,7 @@
   "ingress_entry": "/",
   "startup": "application",
   "arch": [
+    "aarch64",
     "armv7",
     "amd64",
     "i386"


### PR DESCRIPTION
This change adds support for systems running on `aarch64`. As `libspotify*` is not available on `aarch64`, forked-daapd will then just be built without Spotify support. 

All other architectures are unaffected by these changes.