### PR TITLE
Add aarch64 support for Raspotify addon

### DIFF
--- a/raspotify/Dockerfile
+++ b/raspotify/Dockerfile
@@ -2,17 +2,24 @@ ARG BUILD_FROM=hassioaddons/debian-base:3.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends curl apt-transport-https gnupg2 dirmngr
+ARG BUILD_ARCH
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    curl apt-transport-https gnupg2 dirmngr \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v -
 RUN echo 'deb https://dtcooper.github.io/raspotify raspotify main' | cat > /etc/apt/sources.list.d/raspotify.list
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends raspotify
+
+RUN if [ "$BUILD_ARCH" = "aarch64" ] ; then \
+        dpkg --add-architecture armhf; \
+    fi \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    raspotify \
+    && rm -rf /var/lib/apt/lists/*
 RUN ln -sf /share/raspotify /etc/default/raspotify
 
 COPY rootfs /
 
-ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_REF
 ARG BUILD_VERSION

--- a/raspotify/build.json
+++ b/raspotify/build.json
@@ -1,5 +1,6 @@
 {
     "build_from": {
+        "aarch64": "hassioaddons/debian-base-aarch64:3.0.0",
         "amd64": "hassioaddons/debian-base-amd64:3.0.0",
         "armv7": "hassioaddons/debian-base-armv7:3.0.0",
         "i386": "hassioaddons/debian-base-i386:3.0.0"

--- a/raspotify/config.json
+++ b/raspotify/config.json
@@ -9,6 +9,7 @@
   "ingress": false,
   "startup": "application",
   "arch": [
+    "aarch64",
     "armv7"
   ],
   "boot": "auto",


### PR DESCRIPTION
This change adds aarch64 support for the Raspotify addon. There is no native `raspotify` package for aarch64, but the armhf package can be used instead and works.

Again, all other architectures are unaffected by these changes.

Tested on RPi4B 64bit and RPi3B+ 32bit.