### PR TITLE
Rework Raspotify configuration and pipe handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ Spotify connect server, see [the github page](https://github.com/dtcooper/raspot
 Isn't built with pulseaudio, if there is any interest I could probably add that, let me know.
 
 Configurable through the supervisor interface. Username and password are optional, if you just want to cast locally from your phone you can leave them blank.
-Works great with Forked-DAAPD through a pipe, just use `--backend pipe --device /share/forked-daapd/music/Raspotify` in the backend configuration option.
+
+Works great with Forked-DAAPD through a pipe, just use 
+```yaml
+backend: pipe
+device: /share/forked-daapd/music/Raspotify
+```
+in the add-on configuration.
+
+[Read the full add-on documentation](raspotify/DOCS.md).
 
 # Radicale
 

--- a/raspotify/DOCS.md
+++ b/raspotify/DOCS.md
@@ -1,0 +1,97 @@
+# Home Assistant Add-on: Raspotify
+
+The Raspotify add-on allows you to use your device,
+running Home Assistant, to play your Spotify music. This add-on uses the
+Sotify Connect protocol, which makes it a device that can be controlled
+by all the official clients.
+
+**Note**: _Remember to restart the add-on when the configuration is changed._
+
+Example add-on configuration:
+
+```yaml
+name: Raspotify
+bitrate: 160
+volume_normalisation: true
+backend: alsa
+```
+
+**Note**: _This is just an example, don't copy and paste it! Create your own!_
+
+### Option: `log_level`
+
+The `log_level` option controls the level of log output by the add-on and can
+be changed to be more or less verbose, which might be useful when you are
+dealing with an unknown issue. Possible values are:
+
+- `trace`: Show every detail, like all called internal functions.
+- `debug`: Shows detailed debug information.
+- `info`: Normal (usually) interesting events.
+- `warning`: Exceptional occurrences that are not errors.
+- `error`:  Runtime errors that do not require immediate action.
+- `fatal`: Something went terribly wrong. Add-on becomes unusable.
+
+Please note that each level automatically includes log messages from a
+more severe level, e.g., `debug` also shows `info` messages. By default,
+the `log_level` is set to `info`, which is the recommended setting unless
+you are troubleshooting.
+
+Setting the `log_level` to `debug` will also turn on verbose mode of librespot.
+
+### Option: `name`
+
+The name of your device (the Spotify Connect target), as shown on
+the official Spotify clients.
+
+### Option: `bitrate`
+
+The bitrate Spotify should use. The higher, the better the sound quality,
+however, the add-on consumes more data.
+
+Valid values: `96`, `160` (default) or `320`.
+
+### Option: `username`
+
+**IMPORTANT**: _This requires a Spotify Premium account!_
+
+The username you use to login to your Spotify Premium account. Setting
+this will bind the add-on to your account exclusively.
+
+This can be helpful when experiencing discovery issues on your network or
+to disallow guests on your network to use the add-on.
+
+### Option: `password`
+
+The password you use to login to your Spotify Premium account.
+
+### Option: `volume_normalisation`
+
+Whether to apply volume normalisation.
+
+### Option: `backend`
+
+The backend to use with librespot.
+
+Valid Values are
+- `alsa` for local playback on your host system,
+- `pipe` for writing to a fifo pipe which can be read by the Forked-DAAPD add-on for example. See option `device`.
+
+### Option: `device`
+
+When choosing `backend: pipe` this specifies the file fifo pipe which this add-on writes audio to.
+
+Example:
+```yaml
+backend: pipe
+device: /share/forked-daapd/music/Raspotify
+```
+
+The Raspotify add-on tries to create the pipe at the given path or uses an already existing pipe on each start.
+If it could not create or find a pipe, there will be an error message in the add-on log. Created pipes are not deleted when changing this option.
+
+### Option: `extra_options`
+
+Extra commandline arguments to pass to the librespot call.
+See [Librespot Options](https://github.com/librespot-org/librespot/wiki/Options) for details.
+
+**Note**: _The options `--linear-volume --initial-volume=100` are currently already set within the add-on._

--- a/raspotify/config.json
+++ b/raspotify/config.json
@@ -27,19 +27,20 @@
     "share:rw"
   ],
   "options": {
-    "name": "raspotify",
+    "name": "Raspotify",
     "bitrate": 160,
-    "username": "",
-    "password": "",
-    "extra_options": "",
-    "backend": "--backend alsa"
+    "volume_normalisation": true,
+    "backend": "alsa"
   },
   "schema": {
+    "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "name": "str",
-    "bitrate": "int",
+    "bitrate": "list(96|160|320)",
+    "volume_normalisation": "bool",
     "username": "str?",
-    "password": "str?",
-    "extra_options": "str?",
-    "backend": "str"
+    "password": "password?",
+    "backend": "list(alsa|pipe)",
+    "device": "match(^/|(/[\\w-]+)+$)?",
+    "extra_options": "str?"
   }
 }

--- a/raspotify/rootfs/etc/services.d/raspotify/run
+++ b/raspotify/rootfs/etc/services.d/raspotify/run
@@ -5,22 +5,47 @@
 # ==============================================================================
 # shellcheck disable=SC1091
 
-bashio::log.info 'Starting the raspotify Server...'
 # Run raspotify
-
 DEVICE_NAME="$(bashio::config 'name')"
-BACKEND_ARGS="$(bashio::config 'backend')"
 BITRATE="$(bashio::config 'bitrate')"
-OPTIONS="$(bashio::config 'extra_options')"
+BACKEND="$(bashio::config 'backend')"
 
-USERNAME="$(bashio::config 'username')"
-PASSWORD="$(bashio::config 'password')"
-
-VOLUME_ARGS="--enable-volume-normalisation --linear-volume --initial-volume=100"
-
-if [ ! -z ${USERNAME} ] && [ ! -z ${PASSWORD} ]
-then
-	OPTIONS='--username '"${USERNAME}"' --password '"${PASSWORD}"' '"${OPTIONS}"
+if bashio::config.has_value 'extra_options'; then
+	OPTIONS="$(bashio::config 'extra_options')"
+else
+	OPTIONS=""
 fi
 
-exec /usr/bin/librespot --name "${DEVICE_NAME}" $BACKEND_ARGS --bitrate ${BITRATE} $VOLUME_ARGS $OPTIONS
+if bashio::config.equals 'backend' 'pipe'; then
+	if bashio::config.exists 'device' && bashio::config.has_value 'device'; then
+		DEVICE=$(bashio::config 'device')
+		OPTIONS='--device '"${DEVICE}"' '"${OPTIONS}"
+		if [ -p "${DEVICE}" ]; then
+			bashio::log.info "Pipe '${DEVICE}' already exists - using that one."
+		else
+			if $(mkfifo -m 666 "${DEVICE}"); then
+				bashio::log.info "Created pipe at '${DEVICE}'."
+			else
+				bashio::log.error "Could not create pipe at '${DEVICE}'. Maybe a file exists at that path?"
+			fi
+		fi
+	else
+		bashio::log.error "Found 'backend: pipe' in configuration but no value for 'device'."
+	fi
+fi
+
+if bashio::config.has_value 'username' && bashio::config.has_value 'password'; then
+	OPTIONS='--username '"$(bashio::config 'username')"' --password '"$(bashio::config 'password')"' '"${OPTIONS}"
+fi
+
+if bashio::config.equals 'volume_normalisation' true; then
+	OPTIONS='--enable-volume-normalisation '"${OPTIONS}"
+fi
+OPTIONS='--linear-volume --initial-volume=100 '"${OPTIONS}"
+
+if bashio::config.equals 'log_level' 'debug'; then
+	OPTIONS='--verbose '"${OPTIONS}"
+fi
+
+bashio::log.info 'Starting the raspotify Server...'
+exec /usr/bin/librespot --name "${DEVICE_NAME}" --backend $BACKEND --bitrate ${BITRATE} ${OPTIONS}


### PR DESCRIPTION
This change adds some config options for the Raspotify addon:
- `volume_normalisation` can be turned on and off
- the options `backend` and `device` are seperated
- if `log_level: debug`, librespot is started with the `--verbose` option

A fifo pipe is automatically crated / reused when 
```yaml
backend: pipe
device: /share/forked-daapd/music/Raspotify
```
is configured and some error/info messages appear in the add-on log regarding the pipe handling.

A separate documentation file also got added.

Works and tested on RPi3B+ 32bit so far, however, I did not test all combinations of option values but mainly the options regarding the pipe handling.