### PR TITLE
Fix port of 'Open Web UI' button

### DIFF
--- a/forked-daapd/config.json
+++ b/forked-daapd/config.json
@@ -5,7 +5,7 @@
   "panel_icon": "mdi:music-circle",
   "description": "Linux/FreeBSD DAAP (iTunes) and MPD media server with support for AirPlay devices (multiroom), Apple Remote (and compatibles), Chromecast, Spotify and internet radio.",
   "url": "https://github.com/ulrar/addon-forked-daapd",
-  "webui": "http://[HOST]:[PORT:80]/",
+  "webui": "http://[HOST]:[PORT:3689]/",
   "stage": "experimental",
   "ingress": false,
   "ingress_port": 1337,


### PR DESCRIPTION
This changes the default port (was 80) for the 'Open Web UI' button on the add-on page to 3689 so that button does actually open the Forked-DAAPD web ui.

It probably would be more elegant if this would depend on the DAAPD port setting in the future, but I do not know, how this can be done.