### PR TITLE
Set default timing and control ports in Dockerfile

### DIFF
--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -137,7 +137,13 @@ RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
     && sed -i "/trusted_networks\ =/ s/# *//" forked-daapd.conf \
     && sed -i "/pipe_autostart\ =/ s/# *//" forked-daapd.conf \
     && sed -i "/db_path\ =/ s/# *//" forked-daapd.conf \
-    && sed -i "/cache_path\ =/ s/# *//" forked-daapd.conf
+    && sed -i "/cache_path\ =/ s/# *//" forked-daapd.conf \
+    && sed -i "/airplay_shared/ s/# *//" forked-daapd.conf \
+    && sed -i "/control_port\ =/ s/#/ /" forked-daapd.conf \
+    && sed -i "/timing_port\ =/ s/#/ /" forked-daapd.conf \
+    && sed -i "/timing_port/{N;s/\n#/\n/}" forked-daapd.conf \
+    && sed -i "s/\(control_port =\).*/\1 3690/" forked-daapd.conf \
+    && sed -i "s/\(timing_port =\).*/\1 3691/" forked-daapd.conf
 
 # Copy root filesystem
 COPY rootfs /


### PR DESCRIPTION
This change adds sed commands to the Dockerfile so the timing and control ports for Airplay are already set in the config file.

See https://github.com/Ulrar/hassio-addons/issues/9#issuecomment-643738054

These commands change
```bash
#airplay_shared {
        # UDP ports used when airplay devices make connections back to forked-daapd
        # (choosing specific ports may be helpful when running forked-daapd behind a firewall)
#       control_port = 0
#       timing_port = 0
#}
```

to

```bash
airplay_shared {
        # UDP ports used when airplay devices make connections back to forked-daapd
        # (choosing specific ports may be helpful when running forked-daapd behind a firewall)
        control_port = 3690
        timing_port = 3691
}
```

Side Question: Should we also change `#	type = "alsa"` to `	type = "pulseaudio"` already in the Dockerfile as mentioned here https://github.com/Ulrar/hassio-addons/issues/1#issuecomment-640094598 in a similar fashion?