### PR TITLE
Set type = "pulseaudio" in forked-daapd.conf in the Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,6 @@ The defaults should work fine for most uses.
 
 Note that ingress does not work, but you can access the web interface on port 3689.
 
-/!\ You should use pulseaudio as the output type for local playback :
-
-```
-audio {
-...
-	type = "pulseaudio"
-...
-}
-```
-
 Note that Spotify support is not available on `aarch64`.
 
 # Raspotify

--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -41,7 +41,6 @@ ENV BUILD_DEPS_NO_AARCH64 \
 ENV RUN_DEPS \
     libantlr3c-3.4-0 \
     libasound2 \
-    libasound2-plugins \
     libavahi-client3 \
     libavcodec58 \
     libavfilter7 \

--- a/forked-daapd/Dockerfile
+++ b/forked-daapd/Dockerfile
@@ -143,7 +143,9 @@ RUN sed -i -e 's/\(uid.*=.*\)/uid = "root"/g' forked-daapd.conf \
     && sed -i "/timing_port\ =/ s/#/ /" forked-daapd.conf \
     && sed -i "/timing_port/{N;s/\n#/\n/}" forked-daapd.conf \
     && sed -i "s/\(control_port =\).*/\1 3690/" forked-daapd.conf \
-    && sed -i "s/\(timing_port =\).*/\1 3691/" forked-daapd.conf
+    && sed -i "s/\(timing_port =\).*/\1 3691/" forked-daapd.conf \
+    && sed -i "/type\ =/ s/#/ /" forked-daapd.conf \
+    && sed -i 's/\(type =\).*/\1 "pulseaudio"/' forked-daapd.conf
 
 # Copy root filesystem
 COPY rootfs /


### PR DESCRIPTION
This change adds a sed command in the Dockerfile to change the default audio backend from `alsa` to `pulseaudio`. 

See https://github.com/Ulrar/hassio-addons/issues/1#issuecomment-640094598

I also removed the now obsolete warning from the readme and removed libasound2-plugins from the run dependencies. Let me know, if you want to keep them and I revert these commits.